### PR TITLE
Support files that don't end with newline

### DIFF
--- a/apply.go
+++ b/apply.go
@@ -208,7 +208,11 @@ func eatLines(scan *bufio.Scanner, prefix string, n int) error {
 		if !scan.Scan() {
 			return io.ErrUnexpectedEOF
 		}
-		if !bytes.HasPrefix(scan.Bytes(), bprefix) {
+		// diff can inject comments in lines beginning with a backslash, like when
+		// highlighting that the original line had no trailing newline
+		if bytes.HasPrefix(scan.Bytes(), []byte("\\ ")) {
+			i--
+		} else if !bytes.HasPrefix(scan.Bytes(), bprefix) {
 			return fmt.Errorf("line %q does not have expected prefix %q", scan.Bytes(), bprefix)
 		}
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/rogpeppe/apipe
 
 require 9fans.net/go v0.0.0-20180727211846-5d4fa602e1e8
+
+go 1.13


### PR DESCRIPTION
When `diff` compares files where one lacks a trailing newline, it emits:

```
\ No newline at end of file
```

apipe emitted an error because it expected a `---` prefix
